### PR TITLE
solved onnx inference tensor to numpy conversion

### DIFF
--- a/neucodec/model.py
+++ b/neucodec/model.py
@@ -338,6 +338,9 @@ class NeuCodecOnnxDecoder(
             recon: np.array [B, 1, T], reconstructed 24kHz audio
         """
 
+        if isinstance(codes, torch.Tensor):
+            codes = codes.detach().cpu().numpy()
+
         # validate inputs
         if not isinstance(codes, np.ndarray):
             raise ValueError("`Codes` should be an np.array.")


### PR DESCRIPTION
## ONNX Inference

The model supports ONNX inference. PyTorch tensors are automatically converted to numpy arrays for compatibility:
```python
# Tensors are automatically converted to numpy arrays
if isinstance(codes, torch.Tensor):
    codes = codes.detach().cpu().numpy()
```

This ensures seamless integration between PyTorch and ONNX runtime.